### PR TITLE
Support for the constructors of ES6 classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+output.html

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 5.8.0 # Keep in sync with .nvmrc

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/bodylabs/rho-contracts.js/issues"
   },
   "scripts": {
-    "test": "mocha src",
+    "test": "mocha src/*.spec.js",
     "lint": "jshint *.js"
   },
   "author": "Guillaume Marceau <guillaume.marceau@bodylabs.com> (http://bodylabs.com/)",

--- a/src/contract-es6.spec.js
+++ b/src/contract-es6.spec.js
@@ -18,7 +18,7 @@ describe('c.constructs', function () {
 
   describe('with a class', function () {
 
-    class Foo {
+    class ExampleImpl {
       constructor (initialValue) {
         this.value = initialValue;
       }
@@ -33,12 +33,24 @@ describe('c.constructs', function () {
         inc: c.fun().returns(c.number),
       });
 
-    var Wrapped = theContract.wrap(Foo);
+    var Example = theContract.wrap(ExampleImpl);
 
     it('can construct', function () {
-      var wrapped = new Wrapped(10);
+      var instance = new Example(10);
 
-      wrapped.value.should.be.eql(10);
+      instance.value.should.be.eql(10);
+    });
+
+    it('allows `instanceof` and `isA` checks on the wrapped constructor', function () {
+      var instance = new Example(5);
+      instance.should.be['instanceof'](Example);
+      c.isA(Example).check(instance).should.be.ok;
+    });
+
+    it('allows `instanceof` and `isA` checks on the implementation', function () {
+      var instance = new Example(5);
+      instance.should.be['instanceof'](ExampleImpl);
+      c.isA(ExampleImpl).check(instance).should.be.ok;
     });
 
   });

--- a/src/contract-es6.spec.js
+++ b/src/contract-es6.spec.js
@@ -1,0 +1,46 @@
+//  -*- js-indent-level: 2 -*-
+"use strict";
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*jshint eqeqeq:true, bitwise:true, forin:true, immed:true, latedef: true, newcap: true, undef: true, strict:true, node:true */
+/*global describe, it */
+
+var should = require('should');
+var __ = require('underscore');
+var c = require('./contract');
+var fs = require('fs');
+var errors = require('./contract-errors');
+
+describe('c.constructs', function () {
+
+  describe('with a class', function () {
+
+    class Foo {
+      constructor (initialValue) {
+        this.value = initialValue;
+      }
+
+      inc () {
+        this.value++;
+      }
+    }
+
+    var theContract = c.fun({ initialValue: c.number })
+      .constructs({
+        inc: c.fun().returns(c.number),
+      });
+
+    var Wrapped = theContract.wrap(Foo);
+
+    it('can construct', function () {
+      var wrapped = new Wrapped(10);
+
+      wrapped.value.should.be.eql(10);
+    });
+
+  });
+
+});

--- a/src/contract.spec.js
+++ b/src/contract.spec.js
@@ -250,8 +250,8 @@ describe ("object", function () {
 
   it ("wrap maintains prototypes", function () {
     var x = {thk:function(){}};
-    x.__proto__.x = 5;
-    c.object({thk:c.fn()}).wrap(x).__proto__.should.eql({x:5});
+    Object.getPrototypeOf(x).x = 5;
+    Object.getPrototypeOf(c.object({thk:c.fn()}).wrap(x)).should.eql({x:5});
   });
 
   it ("extends passes", function () {

--- a/src/contract.spec.js
+++ b/src/contract.spec.js
@@ -312,11 +312,15 @@ describe ("constructs", function () {
     instance.constructor.should.eql(ExampleImpl);
   });
 
-  it ('allows `instanceof` and `isA` checks', function () {
+  it('allows `instanceof` and `isA` checks on the wrapped constructor', function () {
     var instance = new Example(5);
     instance.should.be['instanceof'](Example);
-    instance.should.be['instanceof'](ExampleImpl);
     c.isA(Example).check(instance).should.be.ok;
+  });
+
+  it('allows `instanceof` and `isA` checks on the implementation', function () {
+    var instance = new Example(5);
+    instance.should.be['instanceof'](ExampleImpl);
     c.isA(ExampleImpl).check(instance).should.be.ok;
   });
 

--- a/src/contract.spec.js
+++ b/src/contract.spec.js
@@ -312,18 +312,6 @@ describe ("constructs", function () {
     instance.constructor.should.eql(ExampleImpl);
   });
 
-  it('allows `instanceof` and `isA` checks on the wrapped constructor', function () {
-    var instance = new Example(5);
-    instance.should.be['instanceof'](Example);
-    c.isA(Example).check(instance).should.be.ok;
-  });
-
-  it('allows `instanceof` and `isA` checks on the implementation', function () {
-    var instance = new Example(5);
-    instance.should.be['instanceof'](ExampleImpl);
-    c.isA(ExampleImpl).check(instance).should.be.ok;
-  });
-
   it ("refuses wrong constructor arguments", function () {
     (function () { new Example("boom"); }).should.throwContract(/ExampleImpl[\s\S]+argument/);
   });
@@ -363,6 +351,18 @@ describe ("constructs", function () {
         _dec: c.fun({i: c.number})
     }).wrap(ChildExampleImpl).should.be.ok;
 
+  });
+
+  it('allows `instanceof` and `isA` checks on the wrapped constructor', function () {
+    var instance = new Example(5);
+    instance.should.be['instanceof'](Example);
+    c.isA(Example).check(instance).should.be.ok;
+  });
+
+  it('allows `instanceof` and `isA` checks on the implementation', function () {
+    var instance = new Example(5);
+    instance.should.be['instanceof'](ExampleImpl);
+    c.isA(ExampleImpl).check(instance).should.be.ok;
   });
 
   it ("supports returning explicitly", function () {

--- a/src/function-contracts.js
+++ b/src/function-contracts.js
@@ -180,8 +180,8 @@ function fnHelper(who, argumentContracts) {
         //
         //
         // Finally, we ensure that `instanceof` checks works when invoked
-        // with both the original `Contructor` and with the new
-        // `WrappedConstructorNoResultCheck`.  This can be acheived by placing both
+        // with both the original contructor and with the new
+        // wrapped constructor, which can be acheived by placing both
         // constructors into prototype chain where the `instanceof`
         // looks for them. `a instanceof Foo` is defined as
         //

--- a/src/function-contracts.js
+++ b/src/function-contracts.js
@@ -141,59 +141,137 @@ function fnHelper(who, argumentContracts) {
         }
       },
 
-      wrapper: function (fn, next, context) {
+      wrapper: function (Constructor, next, context) {
         var self = this;
 
-        // Here we are reusing the normal function wrapper function.
-        // In order to do, we disable the `resultContract` since the normal wrapped
-        // does not check results according to constructor-invocation semantics.
-        // The actual result check is done below.
-        var wrappedFnWithoutResultCheck = oldWrapper.call(u.gentleUpdate(self, { resultContract: c.any }), fn, next, context);
+        //
+        // ES6 requires `new` when invoking constructors, but there is no direct way to
+        // splat an argument array when invoking with `new`. This is a workaround.
+        // cf. http://stackoverflow.com/a/8843181/35902
+        //
+        // `forceNewInvoke` returns a function which, when invoked as `result(1, 2, 3)`
+        // forwards its arguments to `fn` with `new`, aka `new fn(1, 2, 3)`
+        //
+        // This restriction will introduce an additional
+        // complication. ES6 forces the prototype chain of the created
+        // object to that of the _unwrapped_ function, whereas we need
+        // it to be set to the prototype of the _wrapped_ function.
+        //
+        // This is addressed with `setPrototypeOf` below. A solution
+        // without `setPrototypeOf` is possible using ES6's `class`
+        // and `super` keywords.
+        //
+        var forceNewInvoke = function (fn) {
+          return function (/* ... */) {
+            var ReadyToNew = Function.prototype.bind.apply(fn, [null].concat(_.toArray(arguments)));
+            return new ReadyToNew();
+          }
+        };
 
-        var WrappedConstructor = function (/* ... */) {
+        // Checking the input-output behavior of the
+        // `WrappedConstructorNoResultCheck` takes three steps.
+        //
+        // First we reuse the normal function contract's mechanics to
+        // check the inputs.
+        //
+        // Second, we check the return value according to the
+        // constructor-invocation semantics, which has an odd
+        // corner cases.  cf. http://stackoverflow.com/a/1978474/35902
+        //
+        //
+        // Finally, we ensure that `instanceof` checks works when invoked
+        // with both the original `Contructor` and with the new
+        // `WrappedConstructorNoResultCheck`.  This can be acheived by placing both
+        // constructors into prototype chain where the `instanceof`
+        // looks for them. `a instanceof Foo` is defined as
+        //
+        //   in the entire [[Prototype]] chain of `a`, does the object
+        //   arbitrarily pointed to by `Foo.prototype` ever appear?
+        //
+        // cf. https://github.com/getify/You-Dont-Know-JS/blob/master/this%20%26%20object%20prototypes/ch5.md#inspecting-class-relationships
+        //
+        // Graphically, we are constructing this object graph:
+        //
+        //      Constructor         --- .prototype -->   { original methods }
+        //                                                       ^
+        //                                                       |
+        //                                                       | [[Prototype]]
+        //                                                       |
+        //    WrappedConstructorNoResultCheck     --- .prototype -->  { wrapped methods }
+        //                                                       ^
+        //                                                       |
+        //                                                       | [[Prototype]]
+        //                                                       |
+        //                                                constructed object
+        var constructorName = u.functionName(Constructor);
+
+        // Wrap the constructor to check the inputs (with result check disabled)
+        var WrappedConstructorNoResultCheck = oldWrapper.call(u.gentleUpdate(self, { resultContract: c.any }),
+                                                              forceNewInvoke(Constructor),
+                                                              next, u.gentleUpdate(context, { thingName: constructorName }));
+
+
+        var WrappedConstructorWithResultCheck = function (/* ... */) {
           var contextHere = u.clone(context);
           contextHere.stack = u.clone(context.stack);
-          contextHere.thingName = self.thingName || contextHere.thingName;
+          contextHere.thingName = self.thingName || contextHere.thingName || constructorName;
 
-          var receivedResult = wrappedFnWithoutResultCheck.apply(this, arguments);
-          contextHere.stack.push(errors.stackContextItems.result);
+          // Then check the result. If the constructors returns a non-object,
+          // that value is ignored and replaced with `this`
+          function checkResult(receivedResult, replacement) {
+            contextHere.stack.push(errors.stackContextItems.result);
 
-          // Constructor semantic according to the JavaScript standard,
-          // cf. http://stackoverflow.com/a/1978474/35902
-          var resultToCheck;
-          if (_.isObject(receivedResult)) {
-            resultToCheck = receivedResult;
-          } else {
-            resultToCheck = this;
+            var resultToCheck;
+            if (_.isObject(receivedResult)) {
+              resultToCheck = receivedResult;
+            } else {
+              resultToCheck = replacement;
+            }
+            var result = c.privates.checkWrapWContext(self.resultContract, resultToCheck, contextHere);
+            contextHere.stack.pop();
+            return result;
           }
-          var result = c.privates.checkWrapWContext(self.resultContract, resultToCheck, contextHere);
-          contextHere.stack.pop();
+
+          var receivedResult = WrappedConstructorNoResultCheck.apply(this, arguments);
+          var result = checkResult(receivedResult, this);
+
+          Object.setPrototypeOf(result, Object.getPrototypeOf(this));
           return result;
         };
 
-        WrappedConstructor.prototype = Object.create(fn.prototype);
 
-        // Recreate the constructor field, cf. https://github.com/getify/You-Dont-Know-JS/blob/master/this%20&%20object%20prototypes/ch5.md
-        Object.defineProperty(WrappedConstructor.prototype, "constructor" , {
+        function wrapMethod(dest, src, name, contract, thisContract) {
+          var freshContext = _.clone(context);
+          freshContext.thingName = name;
+          if (contract.thisContract === c.any) {
+            contract = u.gentleUpdate(contract, { thisContract: thisContract });
+          }
+          dest[name] = c.privates.checkWrapWContext(contract, src[name], freshContext);
+        }
+
+        function wrapAllMethods(dest, src) {
+          // When a function has no specified `thisContract`, we assume
+          // it is a methods and set the  `thisContract` to `c.is(Constructor)`
+          var newThisContract = c.isA(Constructor);
+          _.each(prototypeFields, function (contract, k) {
+            wrapMethod(dest, src, k, contract, newThisContract);
+          });
+        }
+
+        var wrappedMethods = Object.create(Constructor.prototype)
+        wrapAllMethods(wrappedMethods, Constructor.prototype);
+        WrappedConstructorWithResultCheck.prototype = wrappedMethods;
+
+        // Recreate the constructor field,
+        // cf. https://github.com/getify/You-Dont-Know-JS/blob/master/this%20&%20object%20prototypes/ch5.md
+        Object.defineProperty(WrappedConstructorWithResultCheck.prototype, "constructor" , {
           enumerable: false,
           writable: true,
           configurable: true,
-          value: fn
+          value: Constructor
         });
 
-        var newThisContract = c.isA(fn);
-        _.each(prototypeFields, function (contract, k) {
-          var freshContext = _.clone(context);
-          freshContext.thingName = k;
-          if (contract.thisContract === c.any) {
-            // Functions with no specified `thisContract` are assumed to be methods
-            // and given a `thisContract`
-            contract = u.gentleUpdate(contract, { thisContract: newThisContract });
-          }
-          WrappedConstructor.prototype[k] = c.privates.checkWrapWContext(contract, WrappedConstructor.prototype[k], freshContext);
-        });
-
-        return WrappedConstructor;
+        return WrappedConstructorWithResultCheck;
       }
     });
 

--- a/src/function-contracts.js
+++ b/src/function-contracts.js
@@ -168,8 +168,8 @@ function fnHelper(who, argumentContracts) {
           }
         };
 
-        // Checking the input-output behavior of the
-        // `WrappedConstructorNoResultCheck` takes three steps.
+        // Checking the input-output behavior of `Constructor` takes
+        // three steps.
         //
         // First we reuse the normal function contract's mechanics to
         // check the inputs.
@@ -197,7 +197,7 @@ function fnHelper(who, argumentContracts) {
         //                                                       |
         //                                                       | [[Prototype]]
         //                                                       |
-        //    WrappedConstructorNoResultCheck     --- .prototype -->  { wrapped methods }
+        //    WrappedConstructor     --- .prototype -->  { wrapped methods }
         //                                                       ^
         //                                                       |
         //                                                       | [[Prototype]]

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,9 +21,9 @@ function isMissing(v) {
 }
 
 function clone(obj) {
-  var other = _.clone(obj);
-  other.__proto__ = obj.__proto__;
-  return other;
+    var other = _.clone(obj)
+    Object.setPrototypeOf(other, Object.getPrototypeOf(obj))
+    return other;
 }
 
 function gentleUpdate(obj, spec) { // aka, not an imperative update. aka, no bang.
@@ -46,7 +46,7 @@ var errorMessageInspectionDepth = 5;
 
 function setErrorMessageInspectionDepth(depth) {
   errorMessageInspectionDepth = depth;
-};
+}
 
 function stringify(v) {
   if (isContractInstance(v)) {
@@ -64,7 +64,7 @@ function functionName(fn) {
     } else {
         return null;
     }
-};
+}
 
 module.exports = {
     contractSignal: contractSignal,


### PR DESCRIPTION
The issue is that ES6 is much more opinionated than ES5 about making sure that the prototype chain isn’t messed with. The `prototype` field on classes is read-only, constructors must be invoked with `new`, it’s no longer possible to override `this` when invoking a constructor, etc. All this will make it possible for js implementors to introduce additional jit optimization, which is nice, but it gets in the way of rho-contract’s implementation.

This is a solution using `setPrototypeOf`, which isn’t ideal but fine for now. We can switch to the ES6-based solution that avoids `setPrototypeOf` if there is ever a need.

At the moment, ci is failing since the test for support of ES6 is itself in ES6. I'll configure that next.



