### PR TITLE
removed ref to non-existent 'util' module, replaced calls to util.str…

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,6 +986,17 @@ And also
 
 <a name="related"/>
 
+## React Native
+
+When using `rho-contracts` with React Native, the method `Object.setPrototypeOf` may not
+exist at runtime, in which case you can add the polyfill npm module 
+[`setprototypeof`](https://www.npmjs.com/package/setprototypeof) to your app's dependencies,
+and the following line to the start of your app:
+
+```
+Object.setPrototypeOf = require('setprototypeof')
+```
+
 ## Related Work ##
 
 - `rho-contracts.js` is an implementation of the paper [*Contracts for higher-order

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   ],
   "dependencies": {
     "callsite": "^1.0.0",
-    "underscore": "1.8.x"
+    "underscore": "1.8.x",
+    "stringifier": "1.3.0",
+    "format": "0.2.2"
   },
   "devDependencies": {
     "jshint": "^2.9.1",

--- a/src/contract.impl.js
+++ b/src/contract.impl.js
@@ -7,13 +7,11 @@
 
 /*jshint eqeqeq:true, bitwise:true, forin:true, immed:true, latedef:true, newcap:true, undef:true, strict:false, node:true, loopfunc:true, latedef:false */
 
-var util = require('util');
 var u = require('./utils');
 var _ = require('underscore');
 var errors = require('./contract-errors');
 
 exports.privates = {};
-
 
 // Throughout this file, `var self = this` indicates that the function is
 // intended to be called (and thought of) as a method (regardless of whether

--- a/src/function-contracts.js
+++ b/src/function-contracts.js
@@ -7,8 +7,8 @@
 
 /*jshint eqeqeq:true, bitwise:true, forin:true, immed:true, latedef:true, newcap:true, undef:true, strict:false, node:true, loopfunc:true, latedef:false */
 
-var util = require('util');
 var _ = require('underscore');
+var format = require('format')
 var u = require('./utils');
 var c = require('./contract.impl');
 var errors = require('./contract-errors');
@@ -133,9 +133,9 @@ function fnHelper(who, argumentContracts) {
 
         if (missing.length) {
           var msg =
-              util.format("constructs: some fields present in %s prototype contract are missing on the prototype: %s",
-                          self.thingName ? util.format("%s's", self.thingName) : "the",
-                          missing.join(', '));
+              format("constructs: some fields present in %s prototype contract are missing on the prototype: %s",
+                     self.thingName ? util.format("%s's", self.thingName) : "the",
+                     missing.join(', '));
 
           context.fail(new errors.ContractError(context, msg).fullContract());
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,5 @@
 var _ = require('underscore');
-var util = require('util');
-
+var stringifier = require('stringifier')
 var contractSignal = "M`okY\\xtXVmQzw5dfjjhkDM|Z9@hGy";
 
 function isContractInstance(v) {
@@ -52,7 +51,7 @@ function stringify(v) {
   if (isContractInstance(v)) {
     return v.toString();
   } else {
-    return util.inspect(v, false, errorMessageInspectionDepth, false);
+    return stringifier({ maxDepth: errorMessageInspectionDepth })(v)
   }
 }
 


### PR DESCRIPTION
…ingify and util.format with the stringify and format npm modules.  Also added a section to README on a fglitch using rho-contracts with React Native

The changes can be tested with the `Counter` constructor example in the README, and the following snippet:

```
var hello = c.fn(c.object({ a: c.string })).wrap(function (obj) {
  return "hello"
})

hello({ l1: { l2: { l3: { l4: { l5: { l6: { a: "a" }}}}}}})
```
That will throw a ContractError with the object stringified to the default depth of 5.

I also added a section to the README about a glitch using rho-contracts-fork with React Native.  If there's some other way you'd prefer to handle it, like having rho-contracts itself apply the polyfill, le me know and I can make that change instead.